### PR TITLE
updating zmq deps to work with latest node/zmq

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,12 +28,11 @@
   },
   "main": "lib/index.js",
   "dependencies": {
-    "zmq": "2.5.x",
-    "async": "0.2.x"
+    "async": "^2.0.1",
+    "zmq": "^2.15.3"
   },
   "devDependencies": {
     "watchit": "0.0.4",
-    "async": "0.2.x",
     "coffee-script": "~1.3.1"
   }
 }


### PR DESCRIPTION
zmq 2.5 doesn't compile against v4